### PR TITLE
📝 Clarify that GH Pages is unsuitable for commercial applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ The easiest way to deploy your Power-Up is by compiling it into static files and
 2. Deploy the `dist/` folder to your chosen Hosting Provider:
 	* AWS - [Host a static website using AWS Amplify](https://aws.amazon.com/getting-started/hands-on/host-static-website/) or [Host a static website with Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html)
 	* Azure - [Static website hosting in Azure Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website)
-	* GitHub - [Host a static website with GitHub Pages](https://pages.github.com/)
 	* Heroku - [Host a static website with Heroku Static Buildpack](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-static)
+	* GitHub - [Host a static website with GitHub Pages](https://pages.github.com/) (Not suitable for monetized Power-Ups)
 
 #### Option 2 - Deploy the Power-Up in a Runtime
 


### PR DESCRIPTION
This is because the GH Pages Terms of Service prohibit its usage for providing commercial software as a service (SaaS). Refer to their documentation for further information: https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#prohibited-uses