### PR TITLE
⬆️ Update ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "source-map-loader": "^2.0.1",
     "style-loader": "^2.0.0",
     "ts-loader": "^8.0.18",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.1",
     "type-fest": "^0.21.3",
     "typescript": "^4.2.3",
     "webpack": "^5.26.3",


### PR DESCRIPTION
This PR fixes an issue where the older version of `ts-node` was throwing an error when trying to run the development server.